### PR TITLE
プロフィール設定がガイドラインに準拠していないメンバーにDMで設定をうながす

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle/
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'thor'
+gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    gli (2.19.2)
+    hashie (4.1.0)
+    multipart-post (2.1.1)
+    slack-ruby-client (0.15.1)
+      faraday (>= 1.0)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
+    thor (1.0.1)
+    websocket-driver (0.7.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  slack-ruby-client
+  thor
+
+BUNDLED WITH
+   2.1.4

--- a/bin/ctoa-slack-cli.rb
+++ b/bin/ctoa-slack-cli.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'ctoa/slack/cli'
+
+CTOA::Slack::CLI.start(ARGV)

--- a/lib/ctoa.rb
+++ b/lib/ctoa.rb
@@ -1,0 +1,5 @@
+module CTOA
+  require 'ctoa/util'
+  require 'ctoa/slack'
+  require 'ctoa/slack/cli'
+end

--- a/lib/ctoa/slack.rb
+++ b/lib/ctoa/slack.rb
@@ -1,0 +1,21 @@
+require 'ctoa'
+require 'slack-ruby-client'
+
+class CTOA::Slack
+  def client
+    @client ||= ->() {
+      Slack.configure do |config|
+        config.token = ENV['SLACK_API_TOKEN']
+      end
+      Slack::Web::Client.new
+    }.call
+  end
+
+  def all_members
+    @all_members ||= client.users_list.members
+  end
+
+  def send_dm_to(member, text)
+    client.chat_postMessage(channel: member.id, text: text)
+  end
+end

--- a/lib/ctoa/slack/cli.rb
+++ b/lib/ctoa/slack/cli.rb
@@ -1,0 +1,55 @@
+require 'ctoa'
+require 'thor'
+
+class CTOA::Slack::CLI < Thor
+  desc 'check_profile', 'Slack利用ガイドラインに基づくプロフィール設定がされているかどうかをチェックし、されていない場合にDMでうながす'
+  def check_profile
+    not_compliant_members = 0
+    template = <<~'EOS'
+      <%= member.profile.real_name %>さん、こんにちは！このSlackコミュニティの世話をしている、日本CTO協会理事のあんちぽです！！１
+
+      現在設定されているプロフィールの状態が、Slack利用ガイドラインに準拠していない可能性があるため、改善を提案するべくDMしています！
+
+      CTO協会のSlackコミュニティも数百人規模となりました。コミュニティメンバーの発言の心理的安全性を確保するためにも、みなさんに「Slack利用ガイドライン」に定められているプロフィールの設定をお願いしております。
+
+      Slack利用ガイドラインをあらためてご確認いただき、プロフィールの設定をお願いいたします〜〜〜 :pray:
+
+      ----
+
+      *Slack利用ガイドライン*
+      https://github.com/cto-a/community-management-resources/blob/master/slack-guidelines.md#%E3%83%97%E3%83%AD%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86
+
+      ----
+
+      それでは、Happy Slacking！！１
+    EOS
+
+    slack.all_members.each do |member|
+      if profile_violates_guidelines?(member.profile)
+        not_compliant_members += 1
+        slack.send_dm_to(member, CTOA::Util.render_text(template, binding))
+      end
+    end
+
+    puts <<~EOS
+     メンバー総数: #{slack.all_members.length}（準拠: #{not_compliant_members}、非準拠: #{slack.all_members.length - not_compliant_members}）
+
+     非準拠の#{slack.all_members.length - not_compliant_members}の方に、以下の内容でDMを送りました。
+
+     #{template}
+     EOS
+  end
+
+  private 
+
+  def slack
+    @slack ||= CTOA::Slack.new
+  end
+
+  # Slack利用ガイドライン
+  # https://github.com/cto-a/community-management-resources/blob/master/slack-guidelines.md
+  def profile_violates_guidelines?(profile)
+    profile.title.empty? ||     # 役職・担当
+    profile.display_name.empty? # 準拠してたら空にはならない
+  end
+end

--- a/lib/ctoa/slack/cli.rb
+++ b/lib/ctoa/slack/cli.rb
@@ -2,8 +2,8 @@ require 'ctoa'
 require 'thor'
 
 class CTOA::Slack::CLI < Thor
-  desc 'check_profile', 'Slack利用ガイドラインに基づくプロフィール設定がされているかどうかをチェックし、されていない場合にDMでうながす'
-  def check_profile
+  desc 'check_member_profiles_if_they_comply_slack_guidelines', 'Slack利用ガイドラインに基づくプロフィール設定がされているかどうかをチェックし、されていない場合にDMでうながす'
+  def check_member_profiles_if_they_comply_slack_guidelines
     not_compliant_members = 0
     template = <<~'EOS'
       <%= member.profile.real_name %>さん、こんにちは！このSlackコミュニティの世話をしている、日本CTO協会理事のあんちぽです！！１
@@ -32,12 +32,21 @@ class CTOA::Slack::CLI < Thor
     end
 
     puts <<~EOS
-     メンバー総数: #{slack.all_members.length}（準拠: #{not_compliant_members}、非準拠: #{slack.all_members.length - not_compliant_members}）
+     メンバー総数: #{slack.all_members.length}（準拠: #{slack.all_members.length - not_compliant_members}、非準拠: #{not_compliant_members}）
 
      非準拠の#{slack.all_members.length - not_compliant_members}の方に、以下の内容でDMを送りました。
 
      #{template}
      EOS
+  end
+
+  desc 'num_of_members_whose_profiles_dont_comply_slack_guidelines', 'Slack利用ガイドラインに基づくプロフィール設定がされていない人数を表示する'
+  def num_of_members_whose_profiles_dont_comply_slack_guidelines
+    not_compliant_members = slack.all_members.count do |m|  
+      profile_violates_guidelines?(m.profile)
+    end
+
+    puts "メンバー総数: #{slack.all_members.length}（準拠: #{slack.all_members.length - not_compliant_members}、非準拠: #{not_compliant_members}）"
   end
 
   private 

--- a/lib/ctoa/slack/cli.rb
+++ b/lib/ctoa/slack/cli.rb
@@ -28,6 +28,8 @@ class CTOA::Slack::CLI < Thor
       if profile_violates_guidelines?(member.profile)
         not_compliant_members += 1
         slack.send_dm_to(member, CTOA::Util.render_text(template, binding))
+        puts "DM sent to #{member.profile.real_name}."
+        sleep 1
       end
     end
 

--- a/lib/ctoa/util.rb
+++ b/lib/ctoa/util.rb
@@ -1,0 +1,8 @@
+require 'ctoa'
+require 'erb'
+
+class CTOA::Util
+  def self.render_text(template, b)
+    ERB.new(template).result(b)
+  end
+end


### PR DESCRIPTION
当コミュニティも数百人規模になってきて、お互いが誰なのかわからないひとが増えてきたように思えます。そんな状態だと、際どい話などはなかなか難しくなってしまいます。

そこで、プロフィールの設定が「[Slack利用ガイドライン → プロフィールの設定をしましょう](https://github.com/cto-a/community-management-resources/blob/master/slack-guidelines.md#%E3%83%97%E3%83%AD%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)」に準拠していないメンバーに、DMで設定をうながします。そのことで、メンバー同士のコミュニケーションのやりやすさを醸成します。